### PR TITLE
Avoid docker for windows build problem 

### DIFF
--- a/dockercoins/webui/files/index.html
+++ b/dockercoins/webui/files/index.html
@@ -13,7 +13,7 @@
     color: royalblue;
 }
 </style>
-<script src="jquery.js"></script>
+<script src="jquery-1.11.3.min.js"></script>
 <script src="d3.min.js"></script>
 <script src="rickshaw.min.js"></script>
 <script>

--- a/dockercoins/webui/files/jquery.js
+++ b/dockercoins/webui/files/jquery.js
@@ -1,1 +1,0 @@
-jquery-1.11.3.min.js


### PR DESCRIPTION
Comes up during Docker Fundamentals when students use Docker for Windows to complete the docker-compose exercise. Bypassing the JQuery.js link file avoids the problem.